### PR TITLE
Botania & RFTools Korrektur

### DIFF
--- a/scripts/Botania.zs
+++ b/scripts/Botania.zs
@@ -1,0 +1,7 @@
+# Remove Shard of Laputa
+
+recipes.remove(<Botania:laputaShard>);
+recipes.remove(<Botania:laputaShard:4>);
+recipes.remove(<Botania:laputaShard:9>);
+recipes.remove(<Botania:laputaShard:14>);
+recipes.remove(<Botania:laputaShard:19>);

--- a/scripts/RFTools.zs
+++ b/scripts/RFTools.zs
@@ -13,7 +13,7 @@ recipes.remove(<rftools:dimensionEditorBlock>);
 recipes.remove(<rftools:machineFrame>);
 recipes.addShaped(<rftools:machineFrame>, [
     [ <minecraft:iron_ingot>, <minecraft:dye:4>, <minecraft:iron_ingot> ],
-    [ <minecraft:gold_nugget>, null, <minecraft:gold_nugget> ],
+    [ <ore:ingotSilver>, <ore:blockGlass>, <ore:ingotSilver> ],
     [ <minecraft:iron_ingot>, <minecraft:dye:4>, <minecraft:iron_ingot> ]
 ]);
 


### PR DESCRIPTION
- Botania Shard of Laputa entfernt ( Hebt Erdkugeln aus dem Boden in Höhe ~ 100 )
- RFTools Machine Frame Rezept nun richtig verändert