### PR TITLE
Chunk Loader balancing

### DIFF
--- a/config/immibis.cfg
+++ b/config/immibis.cfg
@@ -31,11 +31,11 @@ general {
     B:chunkloader.enableCrafting=true
 
     # comma-separated list of mod:item-name@meta=number-of-ticks or mod:item-name=number-of-ticks
-    S:chunkloader.fuels=minecraft:stone=60,minecraft:dirt=20,minecraft:ender_pearl=18000,minecraft:netherrack=80,minecraft:cobblestone=20,minecraft:redstone=1200,minecraft:glowstone_dust=2400,minecraft:ender_eye=36000,minecraft:coal@1=1200,minecraft:coal@0=12000,minecraft:magma_cream=18000,minecraft:nether_brick=200
+    S:chunkloader.fuels=TConstruct:MetalBlock@10=360000
     B:chunkloader.hideOtherPlayersLoadersInF9=false
 
     # Maximum number of chunks loaded by each player. Use -2 for unlimited.
-    I:chunkloader.maxChunksPerPlayer=-2
+    I:chunkloader.maxChunksPerPlayer=9
 
     # If true, chunkloaders placed by a player will only load chunks while that player is online.
     B:chunkloader.requireOnline=true


### PR DESCRIPTION
Vorschlag für Dimensional Anchors:
- Fuel Solid Ender = 5 Std pro Chunk Laufzeit.
- Chunks pro Spieler auf 9 limitiert ggf verdoppeln, ist im Vergleich zum MFR Teil jetzt vielleicht etwas wenig.